### PR TITLE
test: add 8 UI tests for ownership, closures, and collections

### DIFF
--- a/tests/ui/closures/closure_as_argument.ko
+++ b/tests/ui/closures/closure_as_argument.ko
@@ -1,0 +1,29 @@
+//@ check-pass
+module closure_as_argument {
+    meta { purpose: "Passing closures as function arguments" }
+
+    fn apply_twice(f: (Int) -> Int, x: Int) -> Int {
+        return f(f(x))
+    }
+
+    fn transform(f: (Int) -> Int, a: Int, b: Int) -> Int {
+        return f(a) + f(b)
+    }
+
+    fn main() {
+        let inc: (Int) -> Int = |x: Int| -> Int { x + 1 }
+        let dbl: (Int) -> Int = |x: Int| -> Int { x * 2 }
+
+        // apply_twice(inc, 0) => inc(inc(0)) => 2
+        let r1: Int = apply_twice(inc, 0)
+        print_int(r1)
+
+        // apply_twice(dbl, 3) => dbl(dbl(3)) => 12
+        let r2: Int = apply_twice(dbl, 3)
+        print_int(r2)
+
+        // transform(dbl, 5, 10) => 10 + 20 => 30
+        let r3: Int = transform(dbl, 5, 10)
+        print_int(r3)
+    }
+}

--- a/tests/ui/closures/closure_capture_mut.ko
+++ b/tests/ui/closures/closure_capture_mut.ko
@@ -1,0 +1,18 @@
+//@ check-pass
+module closure_capture_mut {
+    meta { purpose: "Closure capturing multiple variables from enclosing scope" }
+
+    fn main() {
+        let base: Int = 100
+        let scale: Int = 3
+
+        // Closure captures both base and scale
+        let compute: (Int) -> Int = |x: Int| -> Int { base + x * scale }
+
+        let r1: Int = compute(5)
+        let r2: Int = compute(10)
+
+        print_int(r1)
+        print_int(r2)
+    }
+}

--- a/tests/ui/closures/closure_return_value.ko
+++ b/tests/ui/closures/closure_return_value.ko
@@ -1,0 +1,30 @@
+//@ check-pass
+module closure_return_value {
+    meta { purpose: "Closures returning computed values" }
+
+    fn apply(f: (Int) -> Int, x: Int) -> Int {
+        return f(x)
+    }
+
+    fn main() {
+        // Closure with arithmetic return
+        let square: (Int) -> Int = |x: Int| -> Int { x * x }
+        let s: Int = square(7)
+        print_int(s)
+
+        // Closure with conditional return
+        let abs_val: (Int) -> Int = |x: Int| -> Int {
+            if x < 0 { return 0 - x }
+            return x
+        }
+        let a: Int = abs_val(-5)
+        let b: Int = abs_val(3)
+        print_int(a)
+        print_int(b)
+
+        // Closure used via higher-order function
+        let negate: (Int) -> Int = |x: Int| -> Int { 0 - x }
+        let result: Int = apply(negate, 42)
+        print_int(result)
+    }
+}

--- a/tests/ui/collections/list_higher_order.ko
+++ b/tests/ui/collections/list_higher_order.ko
@@ -1,0 +1,36 @@
+//@ check-pass
+module list_higher_order {
+    meta { purpose: "Higher-order operations on List: map, filter, fold, count, any, all" }
+
+    fn main() {
+        let nums: List<Int> = list_new()
+        list_push(nums, 1)
+        list_push(nums, 2)
+        list_push(nums, 3)
+        list_push(nums, 4)
+        list_push(nums, 5)
+
+        // map: square each element
+        let squares: List<Int> = nums.map(|x: Int| -> Int { x * x })
+        print_int(list_get(squares, 0))
+        print_int(list_get(squares, 4))
+
+        // filter: keep odd numbers
+        let odds: List<Int> = nums.filter(|x: Int| -> Bool { x % 2 != 0 })
+        print_int(list_length(odds))
+
+        // fold: compute sum
+        let sum: Int = nums.fold(0, |acc: Int, x: Int| -> Int { acc + x })
+        print_int(sum)
+
+        // count: count elements > 2
+        let big: Int = nums.count(|x: Int| -> Bool { x > 2 })
+        print_int(big)
+
+        // any: is there an element == 5?
+        let has_five: Bool = nums.any(|x: Int| -> Bool { x == 5 })
+
+        // all: are all elements > 0?
+        let all_pos: Bool = nums.all(|x: Int| -> Bool { x > 0 })
+    }
+}

--- a/tests/ui/collections/set_operations.ko
+++ b/tests/ui/collections/set_operations.ko
@@ -1,0 +1,41 @@
+//@ check-pass
+module set_operations_ui {
+    meta { purpose: "Set operations: union, intersection, difference" }
+
+    fn main() {
+        let a: Set<Int> = set_new()
+        a.add(1)
+        a.add(2)
+        a.add(3)
+
+        let b: Set<Int> = set_new()
+        b.add(2)
+        b.add(3)
+        b.add(4)
+
+        // union: {1, 2, 3, 4}
+        let u: Set<Int> = a.union(b)
+        print_int(u.length())
+
+        // intersection: {2, 3}
+        let inter: Set<Int> = a.intersection(b)
+        print_int(inter.length())
+
+        // difference: {1}
+        let diff: Set<Int> = a.difference(b)
+        print_int(diff.length())
+
+        // contains check
+        if a.contains(2) {
+            print_int(1)
+        }
+
+        // remove and check is_empty
+        a.remove(1)
+        a.remove(2)
+        a.remove(3)
+        if a.is_empty() {
+            print_int(1)
+        }
+    }
+}

--- a/tests/ui/ownership/move_semantics.ko
+++ b/tests/ui/ownership/move_semantics.ko
@@ -1,0 +1,23 @@
+//@ check-pass
+module move_semantics_ui {
+    meta { purpose: "Copy types are freely copied, non-Copy types are moved" }
+
+    fn consume(own s: String) {
+        println(s)
+    }
+
+    fn main() {
+        // Primitives (Copy types) can be used after assignment
+        let a: Int = 10
+        let b: Int = a
+        let c: Int = a + b
+        print_int(c)
+
+        // Bool is also Copy
+        let flag: Bool = true
+        let other: Bool = flag
+        if flag {
+            print_int(1)
+        }
+    }
+}

--- a/tests/ui/ownership/own_transfer.ko
+++ b/tests/ui/ownership/own_transfer.ko
@@ -1,0 +1,32 @@
+//@ check-pass
+module own_transfer {
+    meta { purpose: "Ownership transfer with own keyword on structs" }
+
+    struct Payload {
+        value: Int
+    }
+
+    fn consume_payload(own p: Payload) -> Int {
+        return p.value
+    }
+
+    fn borrow_payload(ref p: Payload) -> Int {
+        return p.value
+    }
+
+    fn create_payload(v: Int) -> Payload {
+        return Payload { value: v }
+    }
+
+    fn main() {
+        // Create and borrow — struct remains usable
+        let p: Payload = create_payload(42)
+        let v1: Int = borrow_payload(p)
+        let v2: Int = borrow_payload(p)
+        print_int(v1 + v2)
+
+        // Transfer ownership — after this, p is consumed
+        let result: Int = consume_payload(p)
+        print_int(result)
+    }
+}

--- a/tests/ui/ownership/ref_borrowing.ko
+++ b/tests/ui/ownership/ref_borrowing.ko
@@ -1,0 +1,25 @@
+//@ check-pass
+module ref_borrowing {
+    meta { purpose: "Borrowing with ref allows reuse of non-Copy values" }
+
+    fn read_value(ref s: String) {
+        println(s)
+    }
+
+    fn string_length(ref s: String) -> Int {
+        return s.length()
+    }
+
+    fn main() {
+        let msg: String = "borrowed value"
+        // Multiple ref borrows are allowed
+        read_value(msg)
+        read_value(msg)
+
+        let len: Int = string_length(msg)
+        print_int(len)
+
+        // msg is still usable after ref borrows
+        println(msg)
+    }
+}


### PR DESCRIPTION
## Summary
Adds 8 new UI tests to improve coverage in weak areas:

| Category | Before | After | New Tests |
|----------|--------|-------|-----------|
| ownership | 2 | 5 | move_semantics, ref_borrowing, own_transfer |
| closures | 2 | 5 | closure_capture_mut, closure_as_argument, closure_return_value |
| collections | 4 | 6 | list_higher_order, set_operations |

## Test plan
- [x] All 73 UI tests pass (`make ui-test`)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace` (2511 unit tests pass)

🤖 Generated by Kōdo Architect (TESTER mode)