### PR TITLE
docs: add tuples, visibility, and refinement types guides

### DIFF
--- a/docs/guide/data-types.md
+++ b/docs/guide/data-types.md
@@ -204,6 +204,58 @@ Output:
 21
 ```
 
+## Tuples
+
+A tuple groups a fixed number of values of possibly different types. Unlike structs, tuple fields are accessed by position rather than by name.
+
+### Tuple Literals
+
+Create tuples with parentheses:
+
+```rust
+let pair: (Int, Int) = (42, 99)
+let triple: (Int, String, Bool) = (1, "hello", true)
+```
+
+### Accessing Elements
+
+Use `.0`, `.1`, `.2` etc. to access elements by index:
+
+```rust
+let pair: (Int, Int) = (10, 20)
+let first: Int = pair.0
+let second: Int = pair.1
+```
+
+### Destructuring
+
+Bind all elements at once with destructuring:
+
+```rust
+let triple: (Int, Int, Int) = (1, 2, 3)
+let (a, b, c) = triple
+// a = 1, b = 2, c = 3
+```
+
+### Returning Tuples from Functions
+
+Tuples are useful when a function needs to return multiple values:
+
+```rust
+fn min_max(a: Int, b: Int) -> (Int, Int) {
+    if a < b {
+        return (a, b)
+    }
+    return (b, a)
+}
+
+fn main() {
+    let result: (Int, Int) = min_max(7, 3)
+    print_int(result.0)  // 3
+    print_int(result.1)  // 7
+}
+```
+
 ## Float64
 
 Kōdo supports 64-bit floating-point numbers with full arithmetic:

--- a/docs/guide/modules-and-imports.md
+++ b/docs/guide/modules-and-imports.md
@@ -267,6 +267,63 @@ let result2: Int = math::add(1, 2)
 
 This is equivalent to calling `add(1, 2)` directly — the module prefix makes the origin explicit.
 
+## Visibility
+
+By default, all declarations in a module are **private** — they can only be used within the same module. Use the `pub` keyword to make them accessible from other modules.
+
+### Public vs Private
+
+```rust
+module auth {
+    meta { purpose: "Authentication utilities" }
+
+    // Public — part of the module's API
+    pub struct User {
+        name: String,
+        role: String
+    }
+
+    // Public — callable from other modules
+    pub fn create_user(name: String, role: String) -> User {
+        return User { name: validate_name(name), role: role }
+    }
+
+    // Private — internal helper, not visible outside this module
+    fn validate_name(name: String) -> String {
+        return name
+    }
+}
+```
+
+Importing `auth` gives access to `User` and `create_user`, but not `validate_name`.
+
+### What Can Be `pub`
+
+| Declaration | Default | With `pub` |
+|-------------|---------|------------|
+| `fn` | Private | Callable from other modules |
+| `struct` | Private | Usable as a type from other modules |
+| `enum` | Private | Usable as a type from other modules |
+| `trait` | Private | Implementable from other modules |
+
+### Visibility with Annotations
+
+`pub` works with all Kōdo annotations:
+
+```rust
+@authored_by(agent: "claude")
+@confidence(0.95)
+pub fn process(data: String) -> String
+    requires { data.length() > 0 }
+{
+    return data
+}
+```
+
+### Design Guideline
+
+Keep the public API minimal. Expose only what other modules need, and hide implementation details. This makes refactoring safer — private functions can change freely without breaking callers.
+
 ## Compilation Certificates
 
 When you compile a Kōdo program, the compiler emits a **compilation certificate** alongside the binary. For `hello.ko`, the compiler creates `hello.ko.cert.json`:

--- a/docs/guide/refinement-types.md
+++ b/docs/guide/refinement-types.md
@@ -1,0 +1,134 @@
+# Refinement Types
+
+Refinement types add constraints to existing types, creating subtypes that are validated at runtime and can be verified statically by Z3. They are one of Kōdo's most powerful features for correctness.
+
+## What Are Refinement Types?
+
+A refinement type narrows an existing type with a boolean constraint. Any value of the refined type must satisfy the constraint:
+
+```rust
+// A port number must be between 1 and 65534
+type Port = Int requires { self > 0 && self < 65535 }
+
+// A percentage must be between 0 and 100
+type Percentage = Int requires { self >= 0 && self <= 100 }
+
+// Age must be non-negative
+type Age = Int requires { self >= 0 }
+```
+
+The `self` keyword refers to the value being constrained. The `requires` block is checked at runtime when a value is assigned to the refined type.
+
+## Using Refined Types
+
+Refined types work like their base types — they can be used as parameters, return types, and local variables:
+
+```rust
+fn serve(port: Port) -> Int {
+    return port
+}
+
+fn main() {
+    let p: Port = 8080       // OK — 8080 satisfies self > 0 && self < 65535
+    let result: Int = serve(p)
+    print_int(result)
+}
+```
+
+## Type Aliases Without Constraints
+
+You can also create simple aliases without a constraint:
+
+```rust
+type Name = String
+type UserId = Int
+```
+
+These are transparent aliases — `Name` and `String` are interchangeable. Adding a `requires` block turns them into proper refinement types.
+
+## SMT Verification
+
+When a function receives a refined type parameter, Z3 uses the refinement constraint as an **assumption** to prove the function's own contracts. This is where refinement types become powerful:
+
+```rust
+type Port = Int requires { self > 0 && self < 65535 }
+
+// Z3 can prove this contract automatically because Port guarantees port > 0
+fn serve(port: Port) -> Int
+    requires { port > 0 }
+{
+    return port
+}
+```
+
+With `--contracts=static`, the compiler sends the refinement constraint to Z3 as an axiom. Z3 then proves that `port > 0` is always true when `port` is a `Port` — no runtime check needed.
+
+### Combining Refined Parameters
+
+Multiple refined parameters compound their guarantees:
+
+```rust
+type Percentage = Int requires { self >= 0 && self <= 100 }
+
+fn combine_pct(pct: Percentage, pct2: Percentage) -> Int {
+    // Z3 knows: pct >= 0 && pct <= 100 && pct2 >= 0 && pct2 <= 100
+    // So it can prove: pct + pct2 >= 0
+    let total: Int = pct + pct2
+    return total
+}
+```
+
+## Practical Patterns
+
+### Domain Modeling
+
+Use refinement types to encode domain rules that would otherwise be buried in validation code:
+
+```rust
+type Email = String requires { self.length() > 0 }
+type PositiveInt = Int requires { self > 0 }
+type Latitude = Float64 requires { self >= -90.0 && self <= 90.0 }
+type Longitude = Float64 requires { self >= -180.0 && self <= 180.0 }
+```
+
+### API Boundaries
+
+Refine types at API boundaries to catch invalid input early:
+
+```rust
+type HttpStatus = Int requires { self >= 100 && self <= 599 }
+type PageSize = Int requires { self > 0 && self <= 100 }
+
+fn paginate(page: PositiveInt, size: PageSize) -> List<String> {
+    // Both parameters are guaranteed valid by their types
+    let offset: Int = (page - 1) * size
+    return list_new()
+}
+```
+
+## Relationship with Contracts
+
+Refinement types and function contracts (`requires`/`ensures`) complement each other:
+
+| Feature | Purpose | Scope |
+|---------|---------|-------|
+| Refinement types | Constrain a type's valid values | Every use of the type |
+| `requires` | Precondition on a specific function call | Single function |
+| `ensures` | Postcondition on a function's return value | Single function |
+
+Refinement types are reusable — define `Port` once, use it everywhere. Contracts are local — they express function-specific guarantees.
+
+## Compilation Modes
+
+| Mode | Refinement behavior |
+|------|-------------------|
+| `--contracts=runtime` (default) | Constraint checked at runtime on assignment |
+| `--contracts=static` | Z3 attempts to prove constraint statically; falls back to runtime |
+| `--contracts=none` | Constraints are skipped (use for trusted builds) |
+| `--contracts=recoverable` | Constraint violation returns an error instead of aborting |
+
+## Next Steps
+
+- [Contracts](contracts.md) — function-level `requires` and `ensures`
+- [Ownership](ownership.md) — linear ownership with `own`, `ref`, `mut ref`
+- [Agent Traceability](agent-traceability.md) — `@authored_by`, `@confidence` annotations


### PR DESCRIPTION
## Summary

Resolves the 3 open documentation issues:

- **Tuples** (#11): Added section to `data-types.md` covering tuple literals, element access (`.0`, `.1`), destructuring, and returning tuples from functions
- **Visibility** (#12): Added section to `modules-and-imports.md` covering `pub`/private defaults, what can be `pub`, visibility with annotations, and design guidelines
- **Refinement Types** (#13): New dedicated guide `refinement-types.md` covering type constraints with `requires`, SMT verification with Z3, practical patterns (domain modeling, API boundaries), relationship with contracts, and compilation modes

## Files changed

- `docs/guide/data-types.md` — added Tuples section
- `docs/guide/modules-and-imports.md` — added Visibility section
- `docs/guide/refinement-types.md` — new file (128 lines)

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `make ui-test` 73/73 pass
- [x] Documentation-only changes — no Rust code modified

Closes #11, closes #12, closes #13

🤖 Generated by Kōdo Architect DOCUMENTER mode