### PR TITLE
test: add 3 UI tests for tuples, refinement types, and visibility

### DIFF
--- a/tests/ui/types/refinement_types.ko
+++ b/tests/ui/types/refinement_types.ko
@@ -1,0 +1,21 @@
+//@ check-pass
+module refinement_types_test {
+    meta {
+        purpose: "UI test: refinement types with requires constraints",
+        version: "0.1.0"
+    }
+
+    type Port = Int requires { self > 0 && self < 65535 }
+    type Percentage = Int requires { self >= 0 && self <= 100 }
+    type Age = Int requires { self >= 0 }
+    type Name = String
+
+    fn main() -> Int {
+        let port: Port = 8080
+        let pct: Percentage = 75
+        let age: Age = 30
+        let name: Name = "Kodo"
+
+        return 0
+    }
+}

--- a/tests/ui/types/tuples_basic.ko
+++ b/tests/ui/types/tuples_basic.ko
@@ -1,0 +1,25 @@
+//@ check-pass
+module tuples_basic {
+    meta {
+        purpose: "UI test: tuple literals, indexing, destructuring",
+        version: "0.1.0"
+    }
+
+    fn make_pair(a: Int, b: Int) -> (Int, Int) {
+        return (a, b)
+    }
+
+    fn main() -> Int {
+        let pair: (Int, Int) = (42, 99)
+        let first: Int = pair.0
+        let second: Int = pair.1
+
+        let triple: (Int, Int, Int) = (1, 2, 3)
+        let (a, b, c) = triple
+
+        let result: (Int, Int) = make_pair(10, 20)
+        let x: Int = result.0
+
+        return 0
+    }
+}

--- a/tests/ui/visibility/pub_functions_and_structs.ko
+++ b/tests/ui/visibility/pub_functions_and_structs.ko
@@ -1,0 +1,26 @@
+//@ check-pass
+module visibility_test {
+    meta {
+        purpose: "UI test: pub/private visibility on functions and structs",
+        version: "0.1.0"
+    }
+
+    pub struct Point {
+        x: Int,
+        y: Int
+    }
+
+    pub fn make_point(x: Int, y: Int) -> Point {
+        return Point { x: x, y: y }
+    }
+
+    fn private_helper() -> Int {
+        return 42
+    }
+
+    fn main() -> Int {
+        let p: Point = make_point(3, 4)
+        let val: Int = private_helper()
+        return 0
+    }
+}


### PR DESCRIPTION
## Summary

Adds UI regression tests for 3 language features that had examples and guide documentation but no UI tests.

## Tests added

| File | Feature | Directive |
|------|---------|-----------|
| `types/tuples_basic.ko` | Tuple literals, `.0`/`.1` indexing, destructuring, return types | `check-pass` |
| `types/refinement_types.ko` | `type X = Int requires { ... }` constraints (Port, Percentage, Age) | `check-pass` |
| `visibility/pub_functions_and_structs.ko` | `pub struct`, `pub fn`, private fn | `check-pass` |

## Test plan

- [x] `make ui-test` — 76/76 pass (was 73)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean

🤖 Generated by Kōdo Architect TESTER mode