### PR TITLE
docs: add annotate_demo.ko showcasing all 5 heuristics

### DIFF
--- a/examples/annotate_demo.ko
+++ b/examples/annotate_demo.ko
@@ -1,0 +1,75 @@
+// Demonstrates `kodoc annotate` — the heuristic contract suggestion engine.
+//
+// This module intentionally lacks contracts. Run:
+//   kodoc annotate examples/annotate_demo.ko
+//
+// The engine will suggest contracts based on static analysis:
+//   - Division by parameter → requires { divisor != 0 }
+//   - List index access → requires { index >= 0 }
+//   - Zero-guard pattern → requires { param > 0 }
+//   - Recursive base case → requires { n >= 0 }
+//   - Direct return of parameter → ensures { result == param }
+//
+// For JSON output (AI agent consumption):
+//   kodoc annotate examples/annotate_demo.ko --json
+
+module annotate_demo {
+    meta {
+        purpose: "Showcase kodoc annotate contract inference",
+        version: "0.1.0",
+        author: "Kōdo Team"
+    }
+
+    // Heuristic: division by parameter → requires { b != 0 }
+    fn safe_divide(a: Int, b: Int) -> Int {
+        return a / b
+    }
+
+    // Heuristic: modulo by parameter → requires { divisor != 0 }
+    fn remainder(value: Int, divisor: Int) -> Int {
+        return value % divisor
+    }
+
+    // Heuristic: list index → requires { idx >= 0 }
+    fn get_element(items: List<Int>, idx: Int) -> Int {
+        return list_get(items, idx)
+    }
+
+    // Heuristic: zero-guard pattern → requires { amount > 0 }
+    fn process_payment(amount: Int) -> String {
+        if amount > 0 {
+            return "approved"
+        }
+        return "rejected"
+    }
+
+    // Heuristic: recursive base case → requires { n >= 0 }
+    fn factorial(n: Int) -> Int {
+        if n <= 1 {
+            return 1
+        }
+        return n * factorial(n - 1)
+    }
+
+    // Heuristic: direct return → ensures { result == x }
+    fn identity(x: Int) -> Int {
+        return x
+    }
+
+    // Already annotated — kodoc annotate will skip this
+    fn validated_divide(a: Int, b: Int) -> Int
+        requires { b != 0 }
+    {
+        return a / b
+    }
+
+    fn main() -> Int {
+        let x: Int = safe_divide(10, 3)
+        let r: Int = remainder(10, 3)
+        print_int(x)
+        print_int(r)
+        print_int(factorial(5))
+        print_int(identity(42))
+        return 0
+    }
+}


### PR DESCRIPTION
## Summary

New example file demonstrating `kodoc annotate` — showcases all 5 contract inference heuristics in one file.

## Output

```
$ kodoc annotate examples/annotate_demo.ko
examples/annotate_demo.ko:24: fn safe_divide()
  + requires { b != 0 }    [verified: parameter `b` used as divisor]
examples/annotate_demo.ko:29: fn remainder()
  + requires { divisor != 0 }    [verified: parameter `divisor` used as divisor]
examples/annotate_demo.ko:34: fn get_element()
  + requires { idx >= 0 }    [verified: parameter `idx` used as list index]
examples/annotate_demo.ko:39: fn process_payment()
  + requires { amount > 0 }    [verified: body checks `amount > 0`]
examples/annotate_demo.ko:47: fn factorial()
  + requires { n >= 0 }    [verified: recursive function with base case guard]
examples/annotate_demo.ko:55: fn identity()
  + ensures { result == x }    [verified: function returns `x` unchanged]

6 contract(s) suggested, 6 verified.
```

Also demonstrates that already-annotated functions (`validated_divide`) are correctly skipped.

## Test plan

- [x] `kodoc check examples/annotate_demo.ko` — compiles OK
- [x] `kodoc annotate examples/annotate_demo.ko` — 6 suggestions, 6 verified
- [x] `cargo fmt/clippy` clean
- [x] `make ui-test` 76/76 pass

🤖 Generated by Kōdo Architect BUILDER mode