### PR TITLE
test: add formatter demo example

### DIFF
--- a/examples/formatter_demo.ko
+++ b/examples/formatter_demo.ko
@@ -1,0 +1,83 @@
+// Formatter Demo — showcasing `kodoc fmt` canonical formatting.
+//
+// The `kodoc fmt` command parses a .ko file and re-emits it in
+// canonical form:
+//   - 4-space indentation
+//   - Spaces around operators
+//   - Meta block first after module declaration
+//   - Structs and enums before functions
+//   - Contracts (`requires`/`ensures`) on their own indented lines
+//   - Limitation: comments are not preserved by the formatter
+//
+// Usage:
+//   kodoc fmt examples/formatter_demo.ko            # format in-place
+//   kodoc fmt examples/formatter_demo.ko --check    # check without modifying
+//
+// Compile and run:
+//   kodoc build examples/formatter_demo.ko -o formatter_demo
+//   ./formatter_demo
+
+module formatter_demo {
+    meta {
+        purpose: "Demonstrate kodoc fmt canonical formatting",
+        version: "0.1.0",
+        author: "Kodo Team"
+    }
+
+    struct Point {
+        x: Int
+        y: Int
+    }
+
+    enum Direction {
+        North
+        South
+        East
+        West
+    }
+
+    fn safe_add(a: Int, b: Int) -> Int
+        requires { a >= 0 }
+        requires { b >= 0 }
+        ensures { result > 0 } {
+        return a + b
+    }
+
+    fn describe_direction(d: Direction) -> String {
+        let label: String = match d {
+            Direction::North => "Going north",
+            Direction::South => "Going south",
+            Direction::East => "Going east",
+            Direction::West => "Going west",
+        }
+        return label
+    }
+
+    fn compute(x: Int, y: Int) -> Int {
+        let sum: Int = x + y
+        let product: Int = x * y
+        let check: Bool = sum > 0 && product >= 0
+        if check {
+            return sum + product
+        } else {
+            return 0
+        }
+    }
+
+    fn main() {
+        let result: Int = safe_add(3, 7)
+        println("safe_add(3, 7) =")
+        print_int(result)
+        let p: Point = Point { x: 10, y: 20 }
+        println("Point x =")
+        print_int(p.x)
+        println("Point y =")
+        print_int(p.y)
+        let dir: Direction = Direction::North
+        let desc: String = describe_direction(dir)
+        println(desc)
+        let comp: Int = compute(5, 3)
+        println("compute(5, 3) =")
+        print_int(comp)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `examples/formatter_demo.ko` showcasing `kodoc fmt` capabilities
- Demonstrates canonical formatting: 4-space indentation, operator spacing, struct/enum ordering before functions, contracts on indented lines, meta block first
- Example compiles and runs correctly, exercising structs, enums, contracts, match expressions, and control flow

## Test plan
- [x] `cargo run -p kodoc -- check examples/formatter_demo.ko` passes
- [x] `cargo run -p kodoc -- build examples/formatter_demo.ko` produces working binary
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test -p kodoc` — all 9 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)