### PR TITLE
test: add select statement parser + UI tests

### DIFF
--- a/crates/kodo_parser/src/stmt.rs
+++ b/crates/kodo_parser/src/stmt.rs
@@ -489,4 +489,59 @@ mod tests {
         let stmts = &module.functions[0].body.stmts;
         assert!(matches!(&stmts[0], Stmt::Spawn { .. }));
     }
+
+    #[test]
+    fn parse_select_two_arms() {
+        let source = r#"module test {
+            fn main() {
+                select {
+                    ch1 => |val: Int| { print_int(val) }
+                    ch2 => |msg: Int| { print_int(msg) }
+                }
+            }
+        }"#;
+        let module = parse(source).unwrap_or_else(|e| panic!("parse failed: {e}"));
+        let stmts = &module.functions[0].body.stmts;
+        assert!(
+            matches!(&stmts[0], Stmt::Select { arms, .. } if arms.len() == 2),
+            "expected Select with 2 arms"
+        );
+    }
+
+    #[test]
+    fn parse_select_arm_has_param() {
+        let source = r#"module test {
+            fn main() {
+                select {
+                    ch => |x: Int| { print_int(x) }
+                }
+            }
+        }"#;
+        let module = parse(source).unwrap_or_else(|e| panic!("parse failed: {e}"));
+        if let Stmt::Select { arms, .. } = &module.functions[0].body.stmts[0] {
+            assert_eq!(arms[0].param.name, "x");
+            assert!(arms[0].param.ty.is_some());
+        } else {
+            panic!("expected Select statement");
+        }
+    }
+
+    #[test]
+    fn parse_select_three_arms() {
+        let source = r#"module test {
+            fn main() {
+                select {
+                    a => |v: Int| { print_int(v) }
+                    b => |v: Int| { print_int(v) }
+                    c => |v: Int| { print_int(v) }
+                }
+            }
+        }"#;
+        let module = parse(source).unwrap_or_else(|e| panic!("parse failed: {e}"));
+        let stmts = &module.functions[0].body.stmts;
+        assert!(
+            matches!(&stmts[0], Stmt::Select { arms, .. } if arms.len() == 3),
+            "expected Select with 3 arms"
+        );
+    }
 }

--- a/tests/ui/concurrency/select_parallel.ko
+++ b/tests/ui/concurrency/select_parallel.ko
@@ -1,0 +1,33 @@
+//@ check-pass
+module select_parallel_test {
+    meta {
+        purpose: "UI test: select inside parallel block with two channels",
+        version: "1.9.0"
+    }
+
+    fn main() -> Int {
+        let ch1: Channel<Int> = channel_new()
+        let ch2: Channel<Int> = channel_new()
+
+        parallel {
+            spawn {
+                channel_send(ch1, 10)
+            }
+            spawn {
+                channel_send(ch2, 20)
+            }
+            spawn {
+                select {
+                    ch1 => |val: Int| {
+                        print_int(val)
+                    }
+                    ch2 => |val: Int| {
+                        print_int(val)
+                    }
+                }
+            }
+        }
+
+        return 0
+    }
+}


### PR DESCRIPTION
## Summary

Adds test coverage for the `select {}` statement (v1.9.0).

### Parser unit tests (3)
- `parse_select_two_arms`: Verify 2-arm select parses correctly
- `parse_select_arm_has_param`: Verify param name/type binding on arms
- `parse_select_three_arms`: Verify 3-arm select

### UI test (1)
- `concurrency/select_parallel.ko`: select inside parallel block with 2 channels

### Counts
- Parser tests: 243 → 246
- UI tests: 77 → 78

🤖 Generated by Kōdo Architect TESTER mode