### PR TITLE
fix: trust-only kodo.toml causes spurious warning on build

### DIFF
--- a/crates/kodoc/src/commands/build.rs
+++ b/crates/kodoc/src/commands/build.rs
@@ -548,8 +548,9 @@ fn resolve_manifest_deps(project_dir: &std::path::Path) -> Vec<std::path::PathBu
 
     let manifest = match crate::manifest::read_manifest(project_dir) {
         Ok(m) => m,
-        Err(e) => {
-            eprintln!("warning: {e}");
+        Err(_) => {
+            // kodo.toml exists but may be a trust-only config (no module/version/deps).
+            // Silently skip dependency loading in that case.
             return Vec::new();
         }
     };

--- a/crates/kodoc/src/manifest.rs
+++ b/crates/kodoc/src/manifest.rs
@@ -76,14 +76,33 @@ pub(crate) enum Dependency {
     },
 }
 
+/// Minimal manifest used only for trust config extraction.
+///
+/// Unlike [`Manifest`], this struct does not require `module` or `version`,
+/// allowing a `kodo.toml` that contains only a `[trust]` section to parse
+/// successfully.
+#[derive(Debug, Deserialize, Default)]
+struct TrustOnlyManifest {
+    #[serde(default)]
+    trust: Option<TrustSection>,
+}
+
 /// Loads trust configuration for a source file by looking for `kodo.toml`.
 ///
 /// Searches only the immediate parent directory of `source_file`. Returns
 /// `TrustConfig::default()` (no validation) if no `kodo.toml` exists or
 /// if it has no `[trust]` section.
+///
+/// Accepts both a full project manifest (with `module`/`version`) and a
+/// minimal manifest containing only `[trust]`.
 pub(crate) fn load_trust_config(source_file: &Path) -> kodo_types::TrustConfig {
     let dir = source_file.parent().unwrap_or(Path::new("."));
-    read_manifest(dir)
+    let manifest_path = dir.join("kodo.toml");
+    let content = match std::fs::read_to_string(&manifest_path) {
+        Ok(c) => c,
+        Err(_) => return kodo_types::TrustConfig::default(),
+    };
+    toml::from_str::<TrustOnlyManifest>(&content)
         .ok()
         .and_then(|m| m.trust)
         .map(TrustSection::into_trust_config)


### PR DESCRIPTION
## Problem

After #59, a `kodo.toml` containing only a `[trust]` section (without `module`/`version`) caused two issues:

1. `load_trust_config` used `read_manifest` which requires the full `Manifest` struct — parse failed silently but the trust config was not loaded
2. `run_build` called `read_manifest` separately for dependency resolution and printed a noisy `warning: error: could not parse kodo.toml` to stderr

## Fix

### `manifest.rs`
Introduced a `TrustOnlyManifest` struct (only `trust: Option<TrustSection>`) used exclusively by `load_trust_config`. A minimal `kodo.toml` like this now works correctly:

```toml
[trust]
known_agents    = ["claude", "gpt-4", "copilot", "gemini"]
human_reviewers = ["alice", "bob"]
```

### `commands/build.rs`
Changed the dependency-loading path to silently return `Vec::new()` when `read_manifest` fails — a trust-only config has no `deps`, so skipping dep resolution is the correct behaviour with no need for a warning.

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo test --workspace` — all pass
- [x] A project with only `[trust]` in `kodo.toml` now compiles with no warnings and trust enforcement active

🤖 Generated with [Claude Code](https://claude.com/claude-code)